### PR TITLE
Add docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,22 @@ The database structure itself is stored in `bookmarx.sql`. You should be able to
 
 Add your tags to the 'tags' table, just one tag per row
 
-Install the python requirements via `python -m pip install -r requirements.txt`
-
 Build the docker container with `sudo docker build -t bookmarx .`
 
 Copy `.env-template` to `.env` and fill in the values
 
 You should then be able to run things with this command: `sudo docker run -d -p 8332:8000 --env-file .env bookmarkx`
+
+## Installation and deployment with Docker Compose
+
+You can run one of the following commands to start the application with Docker Compose:
+
+```bash
+# Newer versions of Docker include compose functionality
+docker compose up -d
+# If docker-compose is installed as a separate package
+docker-compose up -d
+```
 
 # Usage
 Right now I just have the API endpoint for submitting a bookmark (I'm much more concerned with being able store things first....retrieve them later). 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3.8'
+
+services:
+  app:
+    build: .
+    ports:
+      - 8000:8000
+    depends_on:
+      - db
+    environment:
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - DB_HOST=db
+      - DB_TABLE=${DB_TABLE}
+      - DB_USER=${DB_USER}
+      - DB_NAME=${DB_NAME}
+      - DB_PASS=${DB_PASS}
+
+  db:
+    image: mariadb:10.5
+    ports:
+      - 3306:3306
+    volumes:
+      - db_data:/var/lib/mysql
+      - ./bookmarx.sql:/docker-entrypoint-initdb.d/db-dump.sql
+    environment:
+      - MARIADB_ROOT_PASSWORD=${DB_PASS}
+      - MYSQL_DATABASE=${DB_NAME}
+      - MYSQL_USER=${DB_USER}
+      - MYSQL_PASSWORD=${DB_PASS}
+
+volumes:
+  db_data:


### PR DESCRIPTION
This commit adds a Docker Compose file that provides encapsulated setup for the app and a MariaDB database for ease of deployment. No changes to the app itself were necessary, and the existing environment variables are used in the docker-compose.yml file to configure the app.

Docker Compose instructions were added to the Installation section of the readme. I also removed an unnecessary step in the installation instructions (`python -m pip install -r requirements.txt`), since the installation focuses on building the Docker image, and the Dockerfile automatically runs that to provide dependencies for the image.